### PR TITLE
[FEAT] Export all types in entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { ADEFetcher } from "./utils/fetcher";
 import type { Credentials } from "./models/auth";
-import { Events, Project, Projects, Resources, Event, Resource } from "./models/timetable";
+import { Events, Project, Projects, Resources, Event, Resource, Memberships, AllMembers, Counters, Constraints, Cost, Activities, Activity, Rights } from "./models/timetable";
 import { getProjects, setProject } from "./services/projectService";
 import { getEvents } from "./services/eventService";
 import { getResources } from "./services/resourceService";
@@ -69,4 +69,4 @@ export class ADEPlanningAPI {
     }
 }
 
-export type { Resources, Events, Projects, Credentials, Resource, Event, Project };
+export type { Events, Project, Projects, Resources, Event, Resource, Memberships, AllMembers, Counters, Constraints, Cost, Activities, Activity, Rights };


### PR DESCRIPTION
This pull request includes changes to the `src/index.ts` file to expand the types being imported and exported from the `timetable` module. These changes ensure that all relevant types are available for use in other parts of the application.

**Changes in `src/index.ts`:**

* Added the following types to the import statement from `./models/timetable`: `Memberships`, `AllMembers`, `Counters`, `Constraints`, `Cost`, `Activities`, `Activity`, `Rights`.
* Updated the export statement to include the newly imported types: `Memberships`, `AllMembers`, `Counters`, `Constraints`, `Cost`, `Activities`, `Activity`, `Rights`.