### PR TITLE
[FIX] Fix type in Resource interface

### DIFF
--- a/src/models/timetable/resources.ts
+++ b/src/models/timetable/resources.ts
@@ -49,9 +49,6 @@ export interface Resource {
     color: Color;
     levelAccess: string;
     owner: string;
-    fromWorkflow?: boolean;
-    nodeId?: number;
-    nodeOrId?: number;
     allMembers: AllMembers;
     memberships: Memberships;
     constraints: Constraints;

--- a/src/models/timetable/resources.ts
+++ b/src/models/timetable/resources.ts
@@ -29,7 +29,7 @@ export interface Resource {
     nbEventsPlaced: number;
     availableQuantity: number;
     number: number;
-    fatherName: number;
+    fatherName: string;
     fatherId: number;
     info: string,
     codeZ: string;


### PR DESCRIPTION
This pull request includes changes to the `Resource` interface in the `src/models/timetable/resources.ts` file. The most important changes involve modifying the type of the `fatherName` property and removing several optional properties.

Changes to `Resource` interface:

* Changed the type of `fatherName` from `number` to `string`.
* Removed unused properties `fromWorkflow`, `nodeId`, and `nodeOrId`.