### PR TITLE
[FEAT] Add getActivities request support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import type { Project, Event, EventParams, EventByDetail, Memberships, AllMember
 import { getProjects, setProject } from "./services/projectService";
 import { getEvents } from "./services/eventService";
 import { getResources } from "./services/resourceService";
+import { getActivities } from "./services/activityService";
 
 export class ADEPlanningAPI {
     private fetcher: ADEFetcher;
@@ -66,6 +67,10 @@ export class ADEPlanningAPI {
      */
     async getResources<T extends number>(params: ResourceParams & { detail: T }): Promise<ResourceByDetail<T>[]> {
         return await getResources(this.fetcher, params);
+    }
+
+    async getActivities<T extends number>(params: ActivityParams & { detail: T }): Promise<ActivityByDetail<T>[]> {
+        return await getActivities(this.fetcher, params);
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export class ADEPlanningAPI {
     }
     
     /**
+     * Get the list of resources.
      * @param params The parameters to pass to the API.
      * @returns A promise that resolves with the list of resources.
      */
@@ -69,6 +70,11 @@ export class ADEPlanningAPI {
         return await getResources(this.fetcher, params);
     }
 
+    /**
+     * Get the list of activities.
+     * @param params The parameters to pass to the API
+     * @returns A promise that resolves with the list of activities.
+     */
     async getActivities<T extends number>(params: ActivityParams & { detail: T }): Promise<ActivityByDetail<T>[]> {
         return await getActivities(this.fetcher, params);
     }

--- a/src/models/timetable/activities.ts
+++ b/src/models/timetable/activities.ts
@@ -49,7 +49,7 @@ export interface Activity8 extends Activity7 {
 }
 
 export interface Activity9 extends Activity8 {
-    weigth: number;
+    weight: number;
     seatsLeft: number;
     maxSeats: number;
     info: string;

--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -3,6 +3,12 @@ import type { ActivityParams, ActivityByDetail } from "../models/timetable";
 import { parseDateFromDDMMYYYYHHMM } from "../utils/date";
 import { parseRGBColor } from "../utils/color";
 
+/**
+ * Get the activities list
+ * @param fetcher ADEFetcher instance
+ * @param params The parameters to pass to the API
+ * @returns A list of activities
+ */
 export async function getActivities<T extends number>(fetcher: ADEFetcher, params: ActivityParams & { detail: T }): Promise<ActivityByDetail<T>[]> {
     const data = await fetcher.get({  function: 'getActivities', ...params }) as { activities?: { activity: any[] } };
 

--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -1,0 +1,119 @@
+import { ADEFetcher } from "../utils/fetcher";
+import type { ActivityParams, ActivityByDetail } from "../models/timetable";
+import { parseDateFromDDMMYYYYHHMM } from "../utils/date";
+import { parseRGBColor } from "../utils/color";
+
+export async function getActivities<T extends number>(fetcher: ADEFetcher, params: ActivityParams & { detail: T }): Promise<ActivityByDetail<T>[]> {
+    const data = await fetcher.get({  function: 'getActivities', ...params }) as { activities?: { activity: any[] } };
+
+    if (!data.activities) {
+        return []
+    }
+
+    return data.activities.activity.map(activity => {
+        const baseActivity = { id: parseInt(activity.$.id, 10) };
+
+        if (params.detail >= 2) {
+            Object.assign(baseActivity, { name: activity.$.name });
+        }
+
+        if (params.detail >= 3) {
+            Object.assign(baseActivity, {
+                type: activity.$.type,
+                folderId: parseInt(activity.$.folderId, 10)
+            })
+        }
+
+        if (params.detail >= 4) {
+            Object.assign(baseActivity, { url: activity.$.url });
+        }
+
+        if (params.detail >= 5) {
+            Object.assign(baseActivity, { size: parseInt(activity.$.size, 10) });
+        }
+
+        if (params.detail >= 6) {
+            Object.assign(baseActivity, { repetition: parseInt(activity.$.repetition, 10) });
+        }
+
+        if (params.detail >= 7) {
+            Object.assign(baseActivity, {
+                lastUpdate: parseDateFromDDMMYYYYHHMM(activity.$.lastUpdate),
+                creation: parseDateFromDDMMYYYYHHMM(activity.$.creation),
+                lastSlot: parseInt(activity.$.lastSlot, 10),
+                lastDay: parseInt(activity.$.lastDay, 10),
+                lastWeek: parseInt(activity.$.lastWeek, 10),
+                firstSlot: parseInt(activity.$.firstSlot, 10),
+                firstDay: parseInt(activity.$.firstDay, 10),
+                firstWeek: parseInt(activity.$.firstWeek, 10),
+                additionalResources: parseInt(activity.$.additionalResources, 10),
+                durationInMinutes: parseInt(activity.$.durationInMinutes, 10),
+                nbEventsPlaced: parseInt(activity.$.nbEventsPlaced, 10),
+                nbEvents: parseInt(activity.$.nbEvents, 10),
+                duration: activity.$.duration
+            })
+        }
+
+        if (params.detail >= 8) {
+            Object.assign(baseActivity, { email: activity.$.email });
+        }
+
+        if (params.detail >= 9) {
+            const seatsLeft = parseInt(activity.$.seatsLeft, 10)
+            const maxSeats = parseInt(activity.$.maxSeats, 10)
+
+            Object.assign(baseActivity, {
+                weight: parseInt(activity.$.weight, 10),
+                seatsLeft: Number.isNaN(seatsLeft) ? -1 : seatsLeft,
+                maxSeats: Number.isNaN(maxSeats) ? -1 : seatsLeft,
+                info: activity.$.info,
+                code: activity.$.code,
+                codeX: activity.$.codeX,
+                codeY: activity.$.codeY,
+                codeZ: activity.$.codeZ,
+                timezone: activity.$.timezone,
+                color: parseRGBColor(activity.$.color)
+            })
+        }
+
+        if (params.detail >= 10) {
+            Object.assign(baseActivity, { isActive: Boolean(activity.$.isActive) })
+        }
+
+        if (params.detail >= 11) {
+            Object.assign(baseActivity, { isNotSameDay: Boolean(activity.$.isNotSameDay) })
+        }
+
+        if (params.detail >= 12) {
+            Object.assign(baseActivity, { isGrouped: Boolean(activity.$.isGrouped) })
+        }
+
+        if (params.detail >= 13) {
+            Object.assign(baseActivity, {
+                isAligned: Boolean(activity.$.isAligned),
+                isSuccessiveDays: Boolean(activity.$.isSuccessiveDays)
+            })
+        }
+
+        if (params.detail >= 14) {
+            Object.assign(baseActivity, {
+                ownerId: parseInt(activity.$.ownerId),
+                owner: activity.$.owner
+            })
+        }
+
+        if (params.detail >= 15) {
+            Object.assign(baseActivity, { resources: {} }) // TODO: Parse resources (without Costs)
+        }
+
+        if (params.detail >= 16) {
+            Object.assign(baseActivity, { resources: {} }) // TODO: Parse resources (with Costs)
+        }
+
+        if (params.detail >= 17) {
+            Object.assign(baseActivity, { events: {} }) // TODO: Parse events
+        }
+
+        return baseActivity;
+    }) as ActivityByDetail<T>[];
+}


### PR DESCRIPTION
This pull request introduces several changes to add support for fetching activities and corrects a typo in the `Activity9` interface. The most important changes include importing and implementing the `getActivities` function, updating the `ADEPlanningAPI` class, and fixing a typo in the `Activity9` interface.

### New activity fetching functionality:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R7): Added import for `getActivities` from `activityService` and implemented the `getActivities` method in the `ADEPlanningAPI` class. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R7) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R65-R80)
* [`src/services/activityService.ts`](diffhunk://#diff-95e18eb4e76eb53f2e94771e8445f3bbe931d02883a9fb1a4e47d5cd8b3232bdR1-R125): Created the `getActivities` function to fetch activities with various detail levels and parse the response accordingly.

### Typo correction:

* [`src/models/timetable/activities.ts`](diffhunk://#diff-3e65d845c226bba9d9f97460116afdc69eb23dae99b602ca136efbb4e8ff9cf6L52-R52): Corrected the typo from `weigth` to `weight` in the `Activity9` interface.